### PR TITLE
Added checks for passing nil commands to ReaFuzz

### DIFF
--- a/lua/reaper-nvim.lua
+++ b/lua/reaper-nvim.lua
@@ -1,26 +1,23 @@
-local commands = require('reaper-nvim/actions')
-local utils = require('reaper-nvim/utils')
+local commands = require("reaper-nvim/actions")
+local utils = require("reaper-nvim/utils")
 
 local M = {}
 
 function M.setup()
-	require('reaper-nvim/commands')
+	require("reaper-nvim/commands")
 end
 
 function M.fuzzy_reaper_action()
-
 	local reaper_keys = {}
 
-	for k,_ in pairs(commands) do
+	for k, _ in pairs(commands) do
 		table.insert(reaper_keys, k)
 	end
 
 	utils.fzf(reaper_keys, function(reaper_action_key)
-			local action_id = commands[reaper_action_key]
-			utils.send_action_osc(action_id)
-		end
-	)
-
+		local action_id = commands[reaper_action_key]
+		utils.send_action_osc(action_id, reaper_action_key)
+	end)
 end
 
 function M.reaper_action_replay()
@@ -55,7 +52,6 @@ function M.repeat_action_prior_to_last()
 	utils.send_action_osc(action_num)
 end
 
-
 function M.run_last_script()
 	local action_num = 41061
 	utils.send_action_osc(action_num)
@@ -65,7 +61,6 @@ function M.undo()
 	local action_num = 40029
 	utils.send_action_osc(action_num)
 end
-
 
 function M.toggle_mixer()
 	local action_num = 40078
@@ -83,37 +78,35 @@ function M.end_of_project()
 end
 
 function M.reaper_urls()
-	local reaper_urls = require('reaper-nvim/urls')
+	local reaper_urls = require("reaper-nvim/urls")
 	local url_keys = {}
 
-	for k,_ in pairs(reaper_urls) do
+	for k, _ in pairs(reaper_urls) do
 		table.insert(url_keys, k)
 	end
 
 	utils.fzf(url_keys, function(url)
-			local thisurl = reaper_urls[url]
-			if thisurl ~= nil then
-				utils.open_url(thisurl)
-			end
+		local thisurl = reaper_urls[url]
+		if thisurl ~= nil then
+			utils.open_url(thisurl)
 		end
-	)
+	end)
 end
 
 function M.reaper_api()
-	local reaper_urls = require('reaper-nvim/api-lua')
+	local reaper_urls = require("reaper-nvim/api-lua")
 	local url_keys = {}
 
-	for _,k in pairs(reaper_urls) do
+	for _, k in pairs(reaper_urls) do
 		table.insert(url_keys, k)
 	end
 
 	utils.fzf(url_keys, function(url)
-			-- Escaping the pound sign is needed otherwise vim will try to expand it
-			local thisurl = 'https://www.cockos.com/reaper/sdk/reascript/reascripthelp.html' .. '\\#' .. url
-			utils.open_url(thisurl)
-			-- utils.send_action_osc(thisurl)
-		end
-	)
+		-- Escaping the pound sign is needed otherwise vim will try to expand it
+		local thisurl = "https://www.cockos.com/reaper/sdk/reascript/reascripthelp.html" .. "\\#" .. url
+		utils.open_url(thisurl)
+		-- utils.send_action_osc(thisurl)
+	end)
 end
 
 return M

--- a/lua/reaper-nvim/utils.lua
+++ b/lua/reaper-nvim/utils.lua
@@ -12,7 +12,7 @@ function M.open_url(url)
 end
 
 function M.fzf(sources, sinkfunc, custom_options)
-	local cmd = fuzzy_func;
+	local cmd = fuzzy_func
 	local fzf_run = vim.fn[cmd .. "#run"]
 	local fzf_wrap = vim.fn[cmd .. "#wrap"]
 
@@ -22,40 +22,55 @@ function M.fzf(sources, sinkfunc, custom_options)
 		-- don't set `sink` or `sink*` here
 	})
 
-	wrapped["sink*"] = nil   -- this line is required if you want to use `sink` only
+	wrapped["sink*"] = nil -- this line is required if you want to use `sink` only
 	wrapped.sink = sinkfunc
 	fzf_run(wrapped)
 end
 
 -- Execute reaper action via OSC
-function M.send_action_osc(action_num)
+function M.send_action_osc(action_num, name)
+	if action_num == nil then
+		return
+	end
 	vim.g.reaper_last_action = action_num
 
 	local argument = "/action"
-	M.send_message(argument, action_num);
+	print("Rea Action = " .. tostring(action_num) .. " Name = " .. (name or "<nil>"))
+	M.send_message(argument, action_num)
 end
 
 function M.silent_shell(cmd)
 	vim.cmd("silent exe '! " .. cmd .. " &'")
 end
 
-
-local osc = require'osc'.new{
-  transport = 'udp',
-  sendAddr = target_ip,
-  sendPort = target_port,
-}
+local osc = require("osc").new({
+	transport = "udp",
+	sendAddr = target_ip,
+	sendPort = target_port,
+})
 
 function M.send_message(address, command_num)
-	local message = osc.new_message{
-		address = address,
-		types = 'i',
-		command_num
-	}
+	if command_num == nil then
+		return
+	end
 
-	local ok, err = osc:send(message)
-	if not ok then
-	print(err)
+	if
+		not pcall(function()
+			local message = osc.new_message({ address = address, types = "i", command_num })
+			local ok, err = osc:send(message)
+			if not ok then
+				print(err)
+			end
+		end)
+	then
+		print(
+			"Address = "
+				.. address
+				.. ", Command = "
+				.. (tostring(command_num) or "<nil>")
+				.. ", type = "
+				.. type(command_num)
+		)
 	end
 end
 


### PR DESCRIPTION
For some reason nil command_nums are being passed when using ReaFuzz. Simply return when they are nil. Also added printing out the action name and value to see what was exactly passed.